### PR TITLE
Respect scale masks when bounding quantized steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - _None._
 
 ### Fixed
+- **Quantizer limit bounding respects scale masks**: When `boundToLimit` clamps
+  voltages at the range edges, the quantizer now searches for the nearest
+  allowed degree inside the window before falling back to the boundary,
+  preventing masked steps from leaking through at the limits.
 - **Strum start-delay timing**: start-delay countdown now ticks once per audio block, keeping subdivision spacing consistent.
 
 ### Removed

--- a/src/core/PolyQuantaCore.cpp
+++ b/src/core/PolyQuantaCore.cpp
@@ -91,8 +91,19 @@ float snapEDO(float volts, const QuantConfig& qc, float boundLimit, bool boundTo
         // Compute min/max step that map inside ±boundLimit volts.
         int maxStep = (int)std::floor(boundLimit * stepsPerVolt);
         int minStep = -maxStep;
-        if (quantStep > maxStep) quantStep = maxStep;
-        else if (quantStep < minStep) quantStep = minStep;
+        if (quantStep > maxStep) {
+            bool found = false;
+            for (int step = maxStep; step >= minStep; --step) {
+                if (_isAllowedStepRootRel(step, qc)) { quantStep = step; found = true; break; }
+            }
+            if (!found) quantStep = maxStep; // fallback: behave like legacy clamp
+        } else if (quantStep < minStep) {
+            bool found = false;
+            for (int step = minStep; step <= maxStep; ++step) {
+                if (_isAllowedStepRootRel(step, qc)) { quantStep = step; found = true; break; }
+            }
+            if (!found) quantStep = minStep; // fallback: behave like legacy clamp
+        }
     }
 
     // Map steps back to volts, remove shift, accounting for period size.
@@ -517,6 +528,21 @@ int pqtests::run_core_tests() {
             int pc = semitones % 12; if (pc < 0) pc += 12;
             assert(allowedPCs.count(pc) > 0 && "Chromatic leak detected in scale quantization");
         }
+    }
+
+    // --- BoundLimit_Pentatonic_RespectsMask ---
+    // Regression: when clamping to ±boundLimit with a sparse mask, ensure we stay on allowed steps.
+    {
+        hi::dsp::QuantConfig qc; qc.edo = 12; qc.periodOct = 1.f; qc.root = 1; // transpose mask so the octave boundary is disallowed
+        qc.useCustom = true; qc.customFollowsRoot = true;
+        qc.customMask12 = 0b010010101001; // same C minor pentatonic mask, but root shift makes step 12 forbidden
+        const float boundLimit = 1.f; // ±1 V window → ±12 semitones
+        const float stepsPerVolt = (float)qc.edo / qc.periodOct;
+        float snappedHi = snapEDO(boundLimit, qc, boundLimit, true);
+        int stepHi = (int)std::round(snappedHi * stepsPerVolt);
+        assert(_isAllowedStepRootRel(stepHi, qc) && "Upper bound clamp emitted disallowed degree");
+        int maxStep = (int)std::floor(boundLimit * stepsPerVolt);
+        assert(stepHi <= maxStep && "Upper bound exceeded computed range");
     }
 
     // --- Hysteresis_BoundaryStability test ---


### PR DESCRIPTION
## Summary
- search for the nearest allowed step inside the ±boundLimit window before clamping quantized results
- retain the legacy boundary fallback when no mask-compliant step exists in range
- add a regression test covering pentatonic quantization with boundToLimit enabled
- document the mask-respecting limit behavior in the changelog

## Testing
- not run (binary unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cb0b7348e483299e0db582c9216921